### PR TITLE
Traefik resource namespace updates

### DIFF
--- a/k8s/ingressroute.yaml
+++ b/k8s/ingressroute.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: blackjack-strip-ingress
@@ -11,7 +11,7 @@ spec:
     prefixes:
       - /blackjack
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: blackjack-dealer


### PR DESCRIPTION
The containo.us traefik resources are deprecated, changing them to traefik.io.